### PR TITLE
Implement meeting querying (without optional attendees)

### DIFF
--- a/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
+++ b/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
@@ -14,10 +14,8 @@
 
 package com.google.sps;
 
-import java.lang.Math; 
-import java.util.Collection;
-import java.util.Collections;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.PriorityQueue;
 
 public final class FindMeetingQuery {
@@ -27,29 +25,30 @@ public final class FindMeetingQuery {
     if (events.size() > 0) {
       initialQueueCapacity = events.size();
     }
-    PriorityQueue<TimeRange> blockingIntervalls = new PriorityQueue<>(initialQueueCapacity, TimeRange.ORDER_BY_START);
-    for(Event event: events) {
-      if (eventContainsRequestAttendee(event, attendees)) {
-        blockingIntervalls.add(event.getWhen());
+    PriorityQueue<TimeRange> blockingIntervals =
+        new PriorityQueue<>(initialQueueCapacity, TimeRange.ORDER_BY_START);
+    for (Event event : events) {
+      if (eventContainsAttendee(event, attendees)) {
+        blockingIntervals.add(event.getWhen());
       }
     }
     ArrayList<TimeRange> freeSlots = new ArrayList<>();
     long duration = request.getDuration();
     if (duration < TimeRange.WHOLE_DAY.duration()) {
-      if (!blockingIntervalls.isEmpty()) {
+      if (!blockingIntervals.isEmpty()) {
         int previousEnd = TimeRange.START_OF_DAY;
-        while(!blockingIntervalls.isEmpty()) {
-          TimeRange timeRange = blockingIntervalls.remove();
-          int intervallDifference =  previousEnd - timeRange.start();
-          if(intervallDifference < 0 && Math.abs(intervallDifference) >= duration) {
+        while (!blockingIntervals.isEmpty()) {
+          TimeRange timeRange = blockingIntervals.remove();
+          int intervalDifference = previousEnd - timeRange.start();
+          if (intervalDifference < 0 && Math.abs(intervalDifference) >= duration) {
             freeSlots.add(TimeRange.fromStartEnd(previousEnd, timeRange.start(), false));
           }
-          if(timeRange.end() > previousEnd) {
+          if (timeRange.end() > previousEnd) {
             previousEnd = timeRange.end();
           }
         }
-        int intervallDifference = previousEnd - TimeRange.END_OF_DAY;
-        if(intervallDifference < 0 && Math.abs(intervallDifference) >= duration) {
+        int intervalDifference = previousEnd - TimeRange.END_OF_DAY;
+        if (intervalDifference < 0 && Math.abs(intervalDifference) >= duration) {
           freeSlots.add(TimeRange.fromStartEnd(previousEnd, TimeRange.END_OF_DAY, true));
         }
       } else {
@@ -59,9 +58,9 @@ public final class FindMeetingQuery {
     return freeSlots;
   }
 
-  private static boolean eventContainsRequestAttendee(Event event, Collection<String> requestAttendees) {
+  private static boolean eventContainsAttendee(Event event, Collection<String> requestAttendees) {
     Collection<String> eventAttendees = event.getAttendees();
-    for(String attendee: requestAttendees) {
+    for (String attendee : requestAttendees) {
       if (eventAttendees.contains(attendee)) {
         return true;
       }


### PR DESCRIPTION
The `query` method in `FindMeetingQuery` (which given a list of attendees for a new meeting and possible blocking events returns possible free slots the new meeting) is now implemented and passes all the tests in `FindMeetingQueryTest`.

The approach is to first add all blocking events that contain at least one attendee from the new meeting to a priority queue, sorted by start time, and then compare adjacent intervals to check whether they overlap or whether there is a large enough gap between them for the new meeting.

There is potentially a nicer way of doing this, but because adding and removing elements in a priority queue is `O(logN)` the overall runtime should be around `O(N*M*logN)` (I think?), where N is the number of blocking events and M the number of attendees. Which is isn't to bad considering that in most realistic scenarios N and M are probably not terribly large.